### PR TITLE
Use dict.get to access card references

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -14,7 +14,7 @@ def make_links(cards):
     return [
         {'source': card['id'], 'target': reference}
         for card in cards
-        for reference in card['references']
+        for reference in card.get('references', [])
         if reference in [card['id'] for card in cards]
     ]
 


### PR DESCRIPTION
The references property is sometimes nonexistent on a card, and trying to access it will throw a `KeyError`. I've replaced the `card['references']` access with a call to `dict.get`, which defaults to an empty list. This will prevent the endpoint from returning an error when it encounters a card without and references.